### PR TITLE
additional feature for fastIR

### DIFF
--- a/fastIR_collector_linux.py
+++ b/fastIR_collector_linux.py
@@ -603,7 +603,6 @@ class Factory(object):
                     c = cl(self.args)
                     for attr in dir(c):
                         if attr != 'args' and not attr.startswith('_'):
-			    self.args['logger'].info(attr)
                             getattr(c, attr)()
 
         pass

--- a/linux.yaml
+++ b/linux.yaml
@@ -1,0 +1,889 @@
+# Linux specific artifacts.
+
+name: AnacronFiles
+doc: Anacron files.
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/etc/anacrontab'
+      - '/etc/cron.daily/*'
+      - '/etc/cron.hourly/*'
+      - '/etc/cron.monthly/*'
+      - '/etc/cron.weekly/*'
+      - '/var/spool/anacron/cron.daily'
+      - '/var/spool/anacron/cron.hourly'
+      - '/var/spool/anacron/cron.monthly'
+      - '/var/spool/anacron/cron.weekly'
+labels: [Configuration Files]
+supported_os: [Linux]
+---
+name: APTSources
+doc: APT package sources list
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/etc/apt/sources.list'
+      - '/etc/apt/sources.list.d/*.list'
+labels: [Configuration Files, System]
+supported_os: [Linux]
+urls: ['http://manpages.ubuntu.com/manpages/trusty/en/man5/sources.list.5.html']
+---
+name: APTTrustKeys
+doc: APT trusted keys
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/etc/apt/trusted.gpg'
+      - '/etc/apt/trusted.gpg.d/*.gpg'
+      - '/etc/apt/trustdb.gpg'
+      - '/usr/share/keyrings/*.gpg'
+labels: [Configuration Files, System]
+supported_os: [Linux]
+urls: ['https://wiki.debian.org/SecureApt']
+---
+name: CronAtAllowDenyFiles
+doc: Files containing users authorised to run cron or at jobs.
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/etc/cron.allow'
+      - '/etc/cron.deny'
+      - '/etc/at.allow'
+      - '/etc/at.deny'
+labels: [Configuration Files]
+supported_os: [Linux]
+urls:
+  - http://manpages.ubuntu.com/manpages/saucy/man5/at.allow.5.html
+  - http://manpages.ubuntu.com/manpages/precise/en/man1/crontab.1.html
+---
+name: DebianPackagesLogFiles
+doc: Linux dpkg log files.
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/var/log/dpkg.log*'
+      - '/var/log/apt/history.log*'
+labels: [Logs]
+supported_os: [Linux]
+---
+name: DebianPackagesStatus
+doc: Linux dpkg status file.
+sources:
+- type: FILE
+  attributes: {paths: ['/var/lib/dpkg/status']}
+labels: [Software]
+supported_os: [Linux]
+---
+name: DebianVersion
+doc: Debian version information.
+sources:
+- type: FILE
+  attributes: {paths: ['/etc/debian_version']}
+provides: [os_release, os_major_version, os_minor_version]
+labels: [Software]
+supported_os: [Linux]
+---
+name: DNSResolvConfFile
+doc: DNS Resolver configuration file.
+sources:
+- type: FILE
+  attributes: {paths: ['/etc/resolv.conf']}
+labels: [Configuration Files]
+supported_os: [Linux]
+urls: ['http://man7.org/linux/man-pages/man5/resolv.conf.5.html']
+---
+name: HostAccessPolicyConfiguration
+doc: Linux files related to host access policy configuration.
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/etc/hosts.allow'
+      - '/etc/hosts.deny'
+labels: [Configuration Files]
+supported_os: [Linux]
+---
+name: IPTablesRules
+doc: List IPTables rules.
+sources:
+- type: COMMAND
+  attributes:
+    args: ["-L", "-n", "-v"]
+    cmd: /sbin/iptables
+labels: [System]
+supported_os: [Linux]
+---
+name: KernelModules
+doc: Kernel modules to be loaded on boot.
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/etc/modules.conf'
+      - '/etc/modprobe.d/*'
+supported_os: [Linux]
+---
+name: LinuxAtJobs
+doc: Linux at jobs.
+sources:
+- type: FILE
+  attributes: {paths: ['/var/spool/at/*']}
+labels: [Configuration Files]
+supported_os: [Linux]
+---
+name: LinuxAuditLogs
+doc: Linux audit log files.
+sources:
+- type: FILE
+  attributes: {paths: ['/var/log/audit/*']}
+labels: [Logs]
+supported_os: [Linux]
+---
+name: LinuxAuthLogs
+doc: Linux auth log files.
+sources:
+- type: FILE
+  attributes: 
+    paths: 
+      - '/var/log/auth.log*'
+      - '/var/log/secure'
+labels: [Logs, Authentication]
+supported_os: [Linux]
+---
+name: LinuxCronLogs
+doc: Linux cron log files.
+sources:
+- type: FILE
+  attributes: {paths: ['/var/log/cron*']}
+labels: [Logs]
+supported_os: [Linux]
+---
+name: LinuxCronTabs
+doc: Crontab files.
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/etc/crontab'
+      - '/etc/cron.d/*'
+      - '/var/spool/cron/**'
+labels: [Configuration Files]
+supported_os: [Linux]
+---
+name: LinuxDaemonLogFiles
+doc: Linux daemon log files.
+sources:
+- type: FILE
+  attributes: {paths: ['/var/log/daemon.log*']}
+labels: [Logs]
+supported_os: [Linux]
+---
+name: LinuxDistributionRelease
+doc: Linux distribution release information of non-LSB compliant systems.
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/etc/enterprise-release'
+      - '/etc/oracle-release'
+      - '/etc/redhat-release'
+      - '/etc/system-release'
+provides: [os_release, os_major_version, os_minor_version]
+labels: [Software]
+supported_os: [Linux]
+---
+name: LinuxDSDTTable
+doc: Linux file containing DSDT table.
+sources:
+- type: FILE
+  attributes: {paths: ['/sys/firmware/acpi/tables/DSDT']}
+labels: [System]
+urls: ['https://www.kernel.org/doc/Documentation/acpi/initrd_table_override.txt']
+supported_os: [Linux]
+---
+name: LinuxFstab
+doc: Linux fstab file.
+sources:
+- type: FILE
+  attributes: {paths: ['/etc/fstab']}
+labels: [System, Configuration Files]
+supported_os: [Linux]
+urls: ['http://en.wikipedia.org/wiki/Fstab']
+---
+name: LinuxGrubConfiguration
+doc: Linux grub configuration file.
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/boot/grub/grub.cfg'
+      - '/boot/grub2/grub.cfg'
+labels: [System, Configuration Files]
+supported_os: [Linux]
+urls: ['https://en.wikipedia.org/wiki/GNU_GRUB']
+---
+name: LinuxHostnameFile
+doc: Linux hostname file.
+sources:
+- type: FILE
+  attributes: {paths: ['/etc/hostname']}
+labels: [Configuration Files, System]
+supported_os: [Linux]
+---
+name: LinuxInitrdFiles
+doc: Initrd (initramfs) files in /boot/ executed on startup.
+sources:
+- type: FILE
+  attributes:
+    paths:
+     -  '/boot/initramfs*'
+     -  '/boot/initrd*'
+labels: [Configuration Files, System]
+supported_os: [Linux]
+urls:
+  - 'http://en.wikipedia.org/wiki/Initrd'
+  - 'https://www.kernel.org/doc/Documentation/initrd.txt'
+---
+name: LinuxKernelLogFiles
+doc: Linux kernel log files.
+sources:
+- type: FILE
+  attributes: {paths: ['/var/log/kern.log*']}
+labels: [Logs]
+supported_os: [Linux]
+---
+name: LinuxLSBInit
+doc: Linux LSB-style init scripts.
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/etc/init.d/*'
+      - '/etc/insserv.conf'
+      - '/etc/insserv.conf.d/**'
+labels: [Configuration Files, System]
+supported_os: [Linux]
+urls: ['https://wiki.debian.org/LSBInitScripts']
+---
+name: LinuxLocalTime
+doc: Local time zone configuation
+sources:
+- type: FILE
+  attributes: {paths: ['/etc/localtime']}
+labels: [System]
+supported_os: [Linux]
+---
+name: LinuxLSBRelease
+doc: |
+  Linux Standard Base (LSB) release information.
+  See: lsb_release(1) man page, or the LSB Specification under the 'Command
+  Behaviour' section.
+sources:
+- type: FILE
+  attributes: {paths: ['/etc/lsb-release']}
+provides: [os_release, os_major_version, os_minor_version]
+labels: [Software]
+supported_os: [Linux]
+---
+name: LinuxMessagesLogFiles
+doc: Linux messages log files.
+sources:
+- type: FILE
+  attributes: {paths: ['/var/log/messages*']}
+labels: [Logs]
+supported_os: [Linux]
+---
+name: LinuxMountCmd
+doc: Linux output of mount
+sources:
+- type: COMMAND
+  attributes:
+    args: []
+    cmd: /bin/mount
+labels: [System]
+supported_os: [Linux]
+---
+name: LinuxMountInfo
+doc: Linux mount options.
+sources:
+- type: ARTIFACT_GROUP
+  attributes:
+    names:
+      - LinuxFstab
+      - LinuxProcMounts
+labels: [System, Configuration Files]
+supported_os: [Linux]
+---
+name: LinuxPamConfigs
+doc: Configuration files for PAM.
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/etc/pam.conf'
+      - '/etc/pam.d'
+      - '/etc/pam.d/*'
+labels: [Authentication, Configuration Files]
+supported_os: [Linux]
+urls: ['http://www.linux-pam.org/']
+---
+name: LinuxPasswdFile
+doc: |
+  Linux passwd file.
+  A passwd file consist of colon seperated values in the format:
+  username:password:uid:gid:full name:home directory:shell
+sources:
+- type: FILE
+  attributes: {paths: ['/etc/passwd']}
+labels: [Configuration Files, System]
+supported_os: [Linux]
+---
+name: LinuxRsyslogConfigs
+doc: Linux rsyslog configurations.
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/etc/rsyslog.conf'
+      - '/etc/rsyslog.d'
+      - '/etc/rsyslog.d/*'
+labels: [Configuration Files, Logs]
+supported_os: [Linux]
+urls: ['http://www.rsyslog.com/doc/rsyslog_conf.html']
+---
+name: LinuxScheduleFiles
+doc: All Linux job scheduling files.
+sources:
+- type: ARTIFACT_GROUP
+  attributes:
+    names:
+      - AnacronFiles
+      - LinuxCronTabs
+      - LinuxAtJobs
+labels: [Configuration Files]
+supported_os: [Linux]
+---
+name: LinuxServices
+doc: Services running on a Linux system.
+sources:
+- type: ARTIFACT_GROUP
+  attributes:
+    names:
+      - LinuxXinetd
+      - LinuxLSBInit
+      - LinuxSysVInit
+labels: [Configuration Files, System]
+supported_os: [Linux]
+---
+name: LinuxSSDTTables
+doc: Linux files containing SSDT table.
+sources:
+- type: FILE
+  attributes: {paths: ['/sys/firmware/acpi/tables/SSDT*']}
+labels: [System]
+urls: ['https://www.kernel.org/doc/Documentation/acpi/initrd_table_override.txt']
+supported_os: [Linux]
+---
+name: LinuxSysLogFiles
+doc: Linux syslog log files.
+sources:
+- type: FILE
+  attributes: {paths: ['/var/log/syslog*']}
+labels: [Logs]
+supported_os: [Linux]
+---
+name: LinuxSyslogNgConfigs
+doc: Linux syslog-ng configurations.
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/etc/syslog-ng/syslog-ng.conf'
+      - '/etc/syslog-ng/conf-d/*.conf'
+labels: [Configuration Files, Logs]
+supported_os: [Linux]
+urls: ['http://linux.die.net/man/5/syslog-ng.conf']
+---
+name: LinuxSystemdOSRelease
+doc: Linux systemd /etc/os-release file
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/etc/os-release'
+      - '/usr/lib/os-release'
+provides: [os_release, os_major_version, os_minor_version]
+labels: [Software]
+supported_os: [Linux]
+urls: ['https://www.freedesktop.org/software/systemd/man/os-release.html']
+---
+name: LinuxSysVInit
+doc: Services started by sysv-style init scripts.
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/etc/rc*.d'
+      - '/etc/rc*.d/*'
+      - '/etc/rc.d/rc*.d/*'
+      - '/etc/rc.d/init.d/*'
+labels: [Configuration Files, System]
+supported_os: [Linux]
+urls:
+  - 'http://savannah.nongnu.org/projects/sysvinit'
+  - 'http://docs.oracle.com/cd/E37670_01/E41138/html/ol_svcscripts.html'
+---
+name: LinuxTimezoneFile
+doc: Linux timezone file.
+sources:
+- type: FILE
+  attributes: {paths: ['/etc/timezone']}
+labels: [Configuration Files, System]
+supported_os: [Linux]
+---
+name: LinuxWtmp
+doc: Linux wtmp file.
+sources:
+- type: FILE
+  attributes: {paths: ['/var/log/wtmp']}
+labels: [Logs, Authentication]
+provides: [users.username, users.last_logon]
+supported_os: [Linux]
+---
+name: LinuxXinetd
+doc: Linux xinetd configurations.
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/etc/xinetd.conf'
+      - '/etc/xinetd.d/**'
+labels: [Configuration Files, System]
+supported_os: [Linux]
+urls: ['http://en.wikipedia.org/wiki/Xinetd']
+---
+name: ListProcessesPsCommand
+doc: Full process listing via the 'ps' command.
+sources:
+- type: COMMAND
+  attributes:
+    args: ['-ef']
+    cmd: /bin/ps
+supported_os: [Linux]
+urls: ['https://gitlab.com/procps-ng/procps']
+---
+name: LoadedKernelModules
+doc: Linux output of lsmod.
+sources:
+- type: COMMAND
+  attributes:
+    args: []
+    cmd: /sbin/lsmod
+supported_os: [Linux]
+---
+name: LoginPolicyConfiguration
+doc: Linux files related to login policy configuration.
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/etc/netgroup'
+      - '/etc/nsswitch.conf'
+      - '/etc/passwd'
+      - '/etc/shadow'
+      - '/etc/security/access.conf'
+      - '/root/.k5login'
+labels: [Authentication, Configuration Files]
+supported_os: [Linux]
+---
+name: NetgroupConfiguration
+doc: Linux netgroup configuration.
+sources:
+- type: FILE
+  attributes: {paths: ['/etc/netgroup']}
+labels: [Authentication, Configuration Files]
+provides: [users.username]
+supported_os: [Linux]
+---
+name: NtpConfFile
+doc: The configuration file for ntpd. e.g. ntp.conf.
+sources:
+- type: FILE
+  attributes: {paths: ['/etc/ntp.conf']}
+labels: [Configuration Files]
+supported_os: [Linux]
+urls: ['https://www.freebsd.org/cgi/man.cgi?query=ntp.conf&sektion=5']
+---
+name: PCIDevicesInfoFiles
+doc: Info and config files for PCI devices located on the system.
+sources:
+- type: FILE
+  attributes:
+     paths:
+        - '/sys/bus/pci/devices/*/vendor'
+        - '/sys/bus/pci/devices/*/device'
+        - '/sys/bus/pci/devices/*/class'
+        - '/sys/bus/pci/devices/*/config'
+labels: [Configuration Files, System]
+urls:
+  - 'https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-bus-pci'
+  - 'https://www.kernel.org/doc/Documentation/filesystems/sysfs-pci.txt'
+  - 'https://wiki.debian.org/HowToIdentifyADevice/PCI'
+supported_os: [Linux]
+---
+name: SSHHostPubKeys
+doc: SSH host public keys
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/etc/ssh/ssh_host_*_key.pub'
+labels: [Authentication, Configuration Files]
+supported_os: [Linux]
+---
+name: ThumbnailCacheFolder
+doc: Thumbnail cache folder.
+sources:
+- type: FILE
+  attributes: {paths: ['%%users.homedir%%/.thumbnails/**3']}
+labels: [Users]
+supported_os: [Linux]
+---
+name: YumSources
+doc: Yum package sources list
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/etc/yum.conf'
+      - '/etc/yum.repos.d/*.repo'
+labels: [Configuration Files, System]
+supported_os: [Linux]
+urls: ['https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/sec-Configuring_Yum_and_Yum_Repositories.html']
+---
+name: ZeitgeistDatabase
+doc: Zeitgeist user activity database.
+sources:
+- type: FILE
+  attributes: {paths: ['%%users.homedir%%/.local/share/zeitgeist/activity.sqlite']}
+labels: [Users, Logs]
+urls: ['http://forensicswiki.org/wiki/Zeitgeist']
+supported_os: [Linux]
+---
+name: ApacheWebLog
+doc: Log from Apache webserver
+sources:
+- type: FILE
+  attributes: 
+    paths: 
+      - '/var/log/apache2/*'
+      - '/var/log/httpd/*'
+supported_os: [Linux]
+---
+name: DatabaseLog
+doc: Log from mysql, mariadb, mongodb database
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/var/log/mysql/*'
+      - '/var/log/mariadb/*'
+      - '/var/log/mongodb/*'
+supported_os: [Linux]
+---
+name: LinuxASLREnabled
+doc: Kernel ASLR state.
+sources:
+- type: FILE
+  attributes: {paths: ['/proc/sys/kernel/randomize_va_space']}
+labels: [System]
+supported_os: [Linux]
+urls: ['https://www.kernel.org/doc/Documentation/sysctl/kernel.txt']
+---
+name: LinuxIgnoreICMPBroadcasts
+doc: Whether the system ignores ICMP pings.
+sources:
+- type: FILE
+  attributes: {paths: ['/proc/sys/net/ipv4/icmp_echo_ignore_broadcasts']}
+labels: [Network, System]
+supported_os: [Linux]
+urls: ['https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt']
+---
+name: LinuxKernelBootloader
+doc: Bootloader state acquired from the kernel.
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/proc/sys/kernel/bootloader_type'
+      - '/proc/sys/kernel/bootloader_version'
+labels: [System]
+supported_os: [Linux]
+urls: ['https://www.kernel.org/doc/Documentation/sysctl/kernel.txt']
+---
+name: LinuxKernelModuleRestrictions
+doc: Module loading controls.
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/proc/sys/kernel/kexec_load_disabled'
+      - '/proc/sys/kernel/modules_disabled'
+labels: [System]
+supported_os: [Linux]
+urls: ['https://www.kernel.org/doc/Documentation/sysctl/kernel.txt']
+---
+name: LinuxKernelModuleTaintStatus
+doc: Taint state of loaded modules (binary blobs, unsigned modules etc).
+sources:
+- type: FILE
+  attributes: {paths: ['/proc/sys/kernel/tainted']}
+labels: [System]
+supported_os: [Linux]
+urls: ['https://www.kernel.org/doc/Documentation/sysctl/kernel.txt']
+---
+name: LinuxNetworkIpForwardingState
+doc: IP forwarding states.
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/proc/sys/net/ipv*/conf/*/forwarding'
+      - '/proc/sys/net/ipv4/conf/*/mc_forwarding'
+      - '/proc/sys/net/ipv4/ip_forward'
+labels: [Network, System]
+supported_os: [Linux]
+urls: ['https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt']
+---
+name: LinuxNetworkPathFilteringSettings
+doc: States that determine how the system responds to route manipulation.
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/proc/sys/net/ipv*/conf/*/accept_source_route'
+      - '/proc/sys/net/ipv4/conf/*/rp_filter'
+      - '/proc/sys/net/ipv4/conf/*/log_martians'
+labels: [Network, System]
+supported_os: [Linux]
+urls: ['https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt']
+---
+name: LinuxNetworkRedirectState
+doc: Redirect send/receive states.
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/proc/sys/net/ipv*/conf/*/accept_redirects'
+      - '/proc/sys/net/ipv4/conf/*/secure_redirects'
+      - '/proc/sys/net/ipv4/conf/*/send_redirects'
+labels: [Network, System]
+supported_os: [Linux]
+urls: ['https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt']
+---
+name: LinuxProcArp
+doc: ARP table via /proc/net/arp.
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/proc/net/arp'
+labels: [Network]
+supported_os: [Linux]
+---
+name: LinuxProcMounts
+doc: Current mounted filesystems.
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/proc/mounts'
+labels: [System]
+supported_os: [Linux]
+urls: ['https://www.kernel.org/doc/Documentation/filesystems/proc.txt']
+---
+name: LinuxProcSysHardeningSettings
+doc: Linux sysctl settings obtained from /proc/sys.
+sources:
+- type: ARTIFACT_GROUP
+  attributes:
+    names:
+      - 'LinuxASLREnabled'
+      - 'LinuxIgnoreICMPBroadcasts'
+      - 'LinuxKernelBootloader'
+      - 'LinuxKernelModuleTaintStatus'
+      - 'LinuxKernelModuleRestrictions'
+      - 'LinuxNetworkIpForwardingState'
+      - 'LinuxNetworkPathFilteringSettings'
+      - 'LinuxNetworkRedirectState'
+      - 'LinuxRestrictedDmesgReadPrivileges'
+      - 'LinuxRestrictedKernelPointerReadPrivileges'
+      - 'LinuxSecureSuidCoreDumps'
+      - 'LinuxSecureFsLinks'
+      - 'LinuxSyncookieState'
+labels: [System]
+supported_os: [Linux]
+---
+name: LinuxRestrictedDmesgReadPrivileges
+doc: Restrict whether non-privileged users can read dmesg.
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/proc/sys/kernel/dmesg_restrict'
+labels: [System]
+supported_os: [Linux]
+urls: ['https://www.kernel.org/doc/Documentation/sysctl/kernel.txt']
+---
+name: LinuxRestrictedKernelPointerReadPrivileges
+doc: Memory address obfuscation settings.
+sources:
+- type: FILE
+  attributes: {paths: ['/proc/sys/kernel/kptr_restrict']}
+labels: [System]
+supported_os: [Linux]
+urls: ['https://www.kernel.org/doc/Documentation/sysctl/kernel.txt']
+---
+name: LinuxSecureFsLinks
+doc: Security controls to restrict operations on links in world writable directories.
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/proc/sys/fs/protected_hardlinks'
+      - '/proc/sys/fs/protected_symlinks'
+labels: [System]
+supported_os: [Linux]
+urls: ['https://www.kernel.org/doc/Documentation/sysctl/fs.txt']
+---
+name: LinuxSecureSuidCoreDumps
+doc: Security controls for suid core dumps.
+sources:
+- type: FILE
+  attributes: {paths: ['/proc/sys/fs/suid_dumpable']}
+labels: [System]
+supported_os: [Linux]
+urls: ['https://www.kernel.org/doc/Documentation/sysctl/fs.txt']
+---
+name: LinuxSyncookieState
+doc: Whether the system uses syncookies.
+sources:
+- type: FILE
+  attributes: {paths: ['/proc/sys/net/ipv4/tcp_syncookies']}
+labels: [Network, System]
+supported_os: [Linux]
+urls: ['https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt']
+---
+name: LinuxSysctlCmd
+doc: Linux output of systctl -a.
+sources:
+- type: COMMAND
+  attributes:
+    args: ["-a"]
+    cmd: /sbin/sysctl
+supported_os: [Linux]
+urls: ['https://www.kernel.org/doc/Documentation/sysctl']
+---
+name: ProcessData
+doc: all processes on kernel
+sources:
+- type: COMMAND
+  attributes:
+    args: ["-aw"]
+    cmd: /bin/ps
+supported_os: [Linux]
+---
+name: NetworkStatus
+doc: connected tcp, udp sockets with process
+sources:
+- type: COMMAND
+  attributes:
+    args: ["-apetul"]
+    cmd: /bin/netstat
+supported_os: [Linux]
+---
+name: NetworkConnection
+doc: processes connected by tcp
+sources:
+- type: COMMAND
+  attributes:
+    args: ["-tp"]
+    cmd: /bin/ss
+supported_os: [Linux]
+---
+name: MetworkConnection
+doc: Processes connected by tcp for CentOS
+sources:
+- type: COMMAND
+  attributes:
+    args: ["-tp"]
+    cmd: /sbin/ss
+supported_os: [Linux]
+---
+name: LoginData
+doc: login data accessed from other ip
+sources:
+- type: COMMAND
+  attributes:
+    args: ["Faixw"]
+    cmd: /bin/last
+supported_os: [Linux]
+---
+name: LoginData
+doc: login data accessed from other ip
+sources:
+- type: COMMAND
+  attributes:
+    args: ["Faixw"]
+    cmd: /usr/bin/last
+supported_os: [Linux]
+---
+name: ProcessTree
+doc: process tree
+sources:
+- type: COMMAND
+  attributes:
+    args: [" "]
+    cmd: /bin/pstree
+supported_os: [Linux]
+---
+name: ProcessTree
+doc: process tree
+sources:
+- type: COMMAND
+  attributes:
+    args: [" "]
+    cmd: /usr/bin/pstree
+supported_os: [Linux]
+---
+name: FileDisk
+doc: sda data
+sources:
+- type: COMMAND
+  attributes:
+    args: ["-l"]
+    cmd: /sbin/fdisk
+supported_os: [Linux]
+---
+name: FileData
+doc: list open files for CentOS
+sources:
+- type: COMMAND
+  attributes:
+    args: ["-i -P -n "]
+    cmd: /sbin/lsof
+supported_os: [Linux]
+---
+name: FileData
+doc: list open files for Ubuntu
+sources:
+- type: COMMAND
+  attributes:
+    args: [" "]
+    cmd: /usr/bin/lsof
+supported_os: [Linux]


### PR DESCRIPTION
I am a Korean student studying Incident Response.
Using fastir and analyzing it was a great help to my study.
I appreciated the convenience of fastir, which is very easy to use on Linux.

We are currently building an IR collection service for Linux.
During the creation of the service, we checked the list of artifacts created by Google and based on this we created a collector.
As I developed the service, I thought it would be nice if this feature was added to fastIR.
I hope that the features we have created will help a little bit with the fastIR service.

I wanted to use Python's basic module like fastIR to implement it, but I used the PyYAML module to manage the artifact list and added artifacts to prifile.

We would like to thank you again for your opportunity to receive good service and please review it positively.